### PR TITLE
issue #40 inconsistent table formatting, attempt #1

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -168,7 +168,6 @@ app_ui <- function(request) {
         tabPanel("Engagement",
 
           property_title_UI(id = "property_mod3"),
-          br(),
           eng_table_UI(id = "eng_table_mod1"),
           br(),
 

--- a/R/mod_tables.R
+++ b/R/mod_tables.R
@@ -99,7 +99,7 @@ eng_table_SERVER <- function(id, oid = NULL, nl_ncc = NULL, dt_proxy = NULL) {
     if (is.null(dt_proxy)) {
       output$eng_table <- renderDT({
         eng_empty_table()
-      }, escape = FALSE)
+      })
 
     } else {
 


### PR DESCRIPTION
- I think this now stops the column names from disappearing under the table when going from engagement table back to variable table